### PR TITLE
Allow to ignore struct fields with tstype:"-"

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ type UserEntry struct {
 
 	Complex    ComplexType `json:"complex"`
 	unexported bool        // Unexported fields are omitted
+	Ignored    bool        `tstype:"-"` // Fields with - are omitted too
 }
 
 type ListUsersResponse struct {

--- a/tygo/write.go
+++ b/tygo/write.go
@@ -132,6 +132,9 @@ func (g *PackageGenerator) writeFields(s *strings.Builder, fields []*ast.Field, 
 			tstypeTag, err := tags.Get("tstype")
 			if err == nil {
 				tstype = tstypeTag.Value()
+				if tstype == "-" {
+					continue
+				}
 			}
 		}
 


### PR DESCRIPTION
Similar to `json:"-"`.

In one of my projects, there's a field with a `json` tag that I don't want to expose via TypeScript. This PR makes that possible.