### PR TITLE
add support for immutable TypeScript fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ _Typescript output_
  * Comments are kept :)
  */
 export type ComplexType = {
-  [key: string]: { [key: number /* uint16 */]: number /* uint32 */ | undefined };
+  [key: string]: {
+    [key: number /* uint16 */]: number /* uint32 */ | undefined;
+  };
 };
 export type UserRole = string;
 export const UserRoleDefault: UserRole = "viewer";
@@ -219,8 +221,29 @@ export interface Nicknames {
 }
 ```
 
+### Readonly fields
+
+Sometimes a field should be immutable, you can `,readonly` to the `tstype` tag to mark a field as `readonly`.
+
+```golang
+// Golang input
+type Cat struct {
+	Name    string `json:"name,readonly"`
+	Owner   string `json:"owner"`
+}
+```
+
+```typescript
+// Typescript output
+export interface Cat {
+  readonly name: string;
+  owner: string;
+}
+```
+
 ## Generics
-Tygo supports generic types (Go version >= 1.18) out of the box. 
+
+Tygo supports generic types (Go version >= 1.18) out of the box.
 
 ```go
 // Golang input
@@ -235,13 +258,17 @@ type ABCD[A, B string, C UnionType, D int64 | bool] struct {
 	D D `json:"d"`
 }
 ```
+
 ```typescript
 // Typescript output
-export type UnionType = 
-    number /* uint64 */ | string
-;
+export type UnionType = number /* uint64 */ | string;
 
-export interface ABCD<A extends string, B extends string, C extends UnionType, D extends number /* int64 */ | boolean> {
+export interface ABCD<
+  A extends string,
+  B extends string,
+  C extends UnionType,
+  D extends number /* int64 */ | boolean
+> {
   a: A;
   b: B;
   c: C;

--- a/examples/abstract/index.ts
+++ b/examples/abstract/index.ts
@@ -53,4 +53,5 @@ export interface StructBar {
   weird: number /* int64 */;
   field_that_should_be_optional?: string;
   field_that_should_not_be_optional: string;
+  readonly field_that_should_be_readonly: string;
 }

--- a/examples/abstract/misc.go
+++ b/examples/abstract/misc.go
@@ -34,6 +34,7 @@ type StructBar struct {
 
 	FieldThatShouldBeOptional    *string `json:"field_that_should_be_optional"`
 	FieldThatShouldNotBeOptional *string `json:"field_that_should_not_be_optional" tstype:",required"`
+	FieldThatShouldBeReadonly    string  `json:"field_that_should_be_readonly" tstype:",readonly"`
 }
 
 // DROPPED: Floating comment at the end

--- a/tygo/write.go
+++ b/tygo/write.go
@@ -169,6 +169,7 @@ func (g *PackageGenerator) writeStructFields(s *strings.Builder, fields []*ast.F
 		// fmt.Println(f.Type)
 		optional := false
 		required := false
+		readonly := false
 
 		var fieldName string
 		if len(f.Names) != 0 && f.Names[0] != nil && len(f.Names[0].Name) != 0 {
@@ -202,6 +203,7 @@ func (g *PackageGenerator) writeStructFields(s *strings.Builder, fields []*ast.F
 					continue
 				}
 				required = tstypeTag.HasOption("required")
+				readonly = tstypeTag.HasOption("readonly")
 			}
 		}
 
@@ -215,6 +217,9 @@ func (g *PackageGenerator) writeStructFields(s *strings.Builder, fields []*ast.F
 		quoted := !validJSName(name)
 		if quoted {
 			s.WriteByte('\'')
+		}
+		if readonly {
+			s.WriteString("readonly ")
 		}
 		s.WriteString(name)
 		if quoted {


### PR DESCRIPTION
Just a small thing that came up when I was generating some REST response types that I wanted to be immutable.

Add `,readonly` to `tstype` tags and the field will be prefaced with the `readonly` keyword.