### PR TITLE
fallback to `unknown` instead of `any`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const defaultFallbackType = "any"
+
 func ReadFromFilepath(cfgFilepath string) tygo.Config {
 	b, err := ioutil.ReadFile(cfgFilepath)
 	if err != nil {
@@ -17,6 +19,13 @@ func ReadFromFilepath(cfgFilepath string) tygo.Config {
 	err = yaml.Unmarshal(b, &conf)
 	if err != nil {
 		log.Fatalf("Could not parse config file froms: %v", err)
+	}
+
+	// apply defaults
+	for _, packageConf := range conf.Packages {
+		if packageConf.FallbackType == "" {
+			packageConf.FallbackType = defaultFallbackType
+		}
 	}
 
 	return conf

--- a/examples/generic/index.ts
+++ b/examples/generic/index.ts
@@ -16,12 +16,12 @@ export type Derived =
     number /* int */ | string // Line comment
 ;
 export type Any = 
-    string | any;
-export type Empty = any;
+    string | unknown;
+export type Empty = unknown;
 export type Something = any;
 export interface EmptyStruct {
 }
-export interface ValAndPtr<V extends any, PT extends (V | undefined), Unused extends number /* uint64 */> {
+export interface ValAndPtr<V extends unknown, PT extends (V | undefined), Unused extends number /* uint64 */> {
   Val: V;
   /**
    * Comment for ptr field

--- a/examples/simple/index.ts
+++ b/examples/simple/index.ts
@@ -20,9 +20,9 @@ export interface UserEntry {
     foo: number /* uint32 */;
     /**
      * An unknown type without a `tstype` tag or mapping in the config file
-     * becomes `any`
+     * uses the `fallback_type`, which defaults to `any`.
      */
-    bar: any /* uuid.UUID */;
+    bar: unknown /* uuid.UUID */;
   }};
   address?: string;
   nickname?: string;

--- a/examples/simple/simple.go
+++ b/examples/simple/simple.go
@@ -20,7 +20,7 @@ type UserEntry struct {
 	Preferences map[string]struct {
 		Foo uint32 `json:"foo"`
 		// An unknown type without a `tstype` tag or mapping in the config file
-		// becomes `any`
+		// uses the `fallback_type`, which defaults to `any`.
 		Bar uuid.UUID `json:"bar"`
 	} `json:"prefs"`
 

--- a/tygo.yaml
+++ b/tygo.yaml
@@ -14,7 +14,9 @@ packages:
     frontmatter: | # We can define some additional text to put at the start of the file.
       export type Something = string | number;
   - path: "github.com/gzuidhof/tygo/examples/simple"
+    fallback_type: unknown
   - path: "github.com/gzuidhof/tygo/examples/generic"
+    fallback_type: unknown
   # Generate the "net/http" output example, note the output is in gitignore as it's pretty big
   - path: "net/http"
     output_path: "./examples/http/index.ts"

--- a/tygo/config.go
+++ b/tygo/config.go
@@ -32,6 +32,9 @@ type PackageConfig struct {
 
 	// Filenames of Go source files that should be included in the Typescript output.
 	IncludeFiles []string `yaml:"include_files"`
+
+	// FallbackType defines the Typescript type used as a fallback for unknown Go types.
+	FallbackType string `yaml:"fallback_type"`
 }
 
 type Config struct {


### PR DESCRIPTION
This improves type safety of generated output.

Reference info [here](https://www.typescriptlang.org/docs/handbook/2/functions.html#unknown).

#### TODO

- [x] handle case where `any` is included in interface type set