### PR TITLE
Change permission mode of generated files

### DIFF
--- a/tygo/generator.go
+++ b/tygo/generator.go
@@ -2,6 +2,7 @@ package tygo
 
 import (
 	"fmt"
+	"fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -73,7 +74,7 @@ func (g *Tygo) Generate() error {
 			return nil
 		}
 
-		err = ioutil.WriteFile(outPath, []byte(code), os.ModePerm)
+		err = ioutil.WriteFile(outPath, []byte(code), fs.FileMode(0664))
 		if err != nil {
 			return nil
 		}


### PR DESCRIPTION
`os.ModePerm`  is 0777, so with executable bit set... which hurt my eyes when listing the directory ;)

Changing to 0664, dropping the executable bits and the write perm by others.