### PR TITLE
Expand version output to include Go version and arch info

### DIFF
--- a/cmd/buildinfo.go
+++ b/cmd/buildinfo.go
@@ -1,11 +1,15 @@
 package cmd
 
+import (
+	"fmt"
+	"runtime"
+)
+
 // Field injected by goreleaser
 var (
 	version    = "<unknown>"
 	commitDate = "date unknown"
 	commit     = ""
-	target     = ""
 )
 
 func Version() string {
@@ -21,5 +25,10 @@ func Commit() string {
 }
 
 func Target() string {
-	return target
+	return runtime.GOOS
+}
+
+func FullVersion() string {
+	return fmt.Sprintf("%s %s/%s %s (%s) %s",
+		version, runtime.GOOS, runtime.GOARCH, runtime.Version(), commitDate, commit)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,7 @@ func Execute() {
 
 	rootCmd.PersistentFlags().
 		String("config", "tygo.yaml", "config file to load (default is tygo.yaml in the current folder)")
-	rootCmd.Version = Version() + " " + Target() + " (" + CommitDate() + ") " + Commit()
+	rootCmd.Version = FullVersion()
 	rootCmd.PersistentFlags().BoolP("debug", "D", false, "Debug mode (prints debug messages)")
 
 	rootCmd.AddCommand(&cobra.Command{

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -8,7 +8,7 @@ builds:
     goarch:
       - amd64
     ldflags:
-      - -s -w -X github.com/gzuidhof/tygo/cmd.version={{.Version}} -X github.com/gzuidhof/tygo/cmd.commit={{.Commit}} -X github.com/gzuidhof/tygo/cmd.commitDate={{.CommitDate}} -X github.com/gzuidhof/tygo/cmd.target={{.Env.GOOS}}
+      - -s -w -X github.com/gzuidhof/tygo/cmd.version={{.Version}} -X github.com/gzuidhof/tygo/cmd.commit={{.Commit}} -X github.com/gzuidhof/tygo/cmd.commitDate={{.CommitDate}}
 archives:
   - id: tygo
     name_template: >-


### PR DESCRIPTION
This augments the output of the `--version` CLI flag to include the Go version and arch information.

Before:
```shell
tygo version 0.2.9-SNAPSHOT-09625a8 linux (2023-08-25T15:00:54Z) 09625a843bb514dd755ac116d203d31a0580ee10
```

After:
```shell
tygo version 0.2.9-SNAPSHOT-ab5c51b linux/amd64 go1.21.1 (2023-10-04T09:01:55Z) ab5c51bd37f87e0df6ee734de8e3684e6948a8cb
```