### PR TITLE
Replace `iota` variable in constant

### DIFF
--- a/tygo/iota.go
+++ b/tygo/iota.go
@@ -1,37 +1,17 @@
 package tygo
 
 import (
-	"log"
+	"regexp"
 	"strconv"
 	"strings"
 )
 
-func isProbablyIotaType(groupType string) bool {
-	groupType = strings.Trim(groupType, "()")
-	return groupType == "iota" || strings.HasPrefix(groupType, "iota +") || strings.HasSuffix(groupType, "+ iota")
+var iotaRegexp = regexp.MustCompile(`\biota\b`)
+
+func isProbablyIotaType(valueString string) bool {
+	return !strings.ContainsAny(valueString, "\"'`") && iotaRegexp.MatchString(valueString)
 }
 
-// Note: this could be done so much more elegantly, but this probably covers 99.9% of iota usecases
-func basicIotaOffsetValueParse(groupType string) int {
-	if !isProbablyIotaType(groupType) {
-		panic("can't parse non-iota type")
-	}
-	groupType = strings.Trim(groupType, "()")
-	if groupType == "iota" {
-		return 0
-	}
-	parts := strings.Split(groupType, " + ")
-
-	var numPart string
-	if parts[0] == "iota" {
-		numPart = parts[1]
-	} else {
-		numPart = parts[0]
-	}
-
-	addValue, err := strconv.ParseInt(numPart, 10, 64)
-	if err != nil {
-		log.Panicf("Failed to guesstimate initial iota value for \"%s\": %v", groupType, err)
-	}
-	return int(addValue)
+func replaceIotaValue(valueString string, iotaValue int) string {
+	return iotaRegexp.ReplaceAllLiteralString(valueString, strconv.Itoa(iotaValue))
 }

--- a/tygo/write_toplevel.go
+++ b/tygo/write_toplevel.go
@@ -15,7 +15,6 @@ type groupContext struct {
 	groupValue           string
 	groupType            string
 	iotaValue            int
-	iotaOffset           int
 }
 
 func (g *PackageGenerator) writeGroupDecl(s *strings.Builder, decl *ast.GenDecl) {
@@ -202,24 +201,14 @@ func (g *PackageGenerator) writeValueSpec(
 			val := vs.Values[i]
 			tempSB := &strings.Builder{}
 			g.writeType(tempSB, val, 0, true)
-			valueString := tempSB.String()
-
-			if isProbablyIotaType(valueString) {
-				group.iotaOffset = basicIotaOffsetValueParse(valueString)
-				group.groupValue = "iota"
-				valueString = fmt.Sprint(group.iotaValue + group.iotaOffset)
-			} else {
-				group.groupValue = valueString
-			}
-			s.WriteString(valueString)
-
-		} else { // We must use the previous value or +1 in case of iota
-			valueString := group.groupValue
-			if group.groupValue == "iota" {
-				valueString = fmt.Sprint(group.iotaValue + group.iotaOffset)
-			}
-			s.WriteString(valueString)
+			group.groupValue = tempSB.String()
 		}
+
+		valueString := group.groupValue
+		if isProbablyIotaType(valueString) {
+			valueString = replaceIotaValue(valueString, group.iotaValue)
+		}
+		s.WriteString(valueString)
 
 		s.WriteByte(';')
 


### PR DESCRIPTION
Fix #41 
```go
package test_tygo

const (
	A1 = -1
	A2 = iota
	A3
)

const (
	B1 = 1 + iota
	B2
	B3
)

const (
	C1 = -iota%2*2 + 1
	C2
	C3
)

```
```ts
// Code generated by tygo. DO NOT EDIT.

//////////
// source: type.go

export const A1 = -1;
export const A2 = 1;
export const A3 = 2;
export const B1 = 1 + 0;
export const B2 = 1 + 1;
export const B3 = 1 + 2;
export const C1 = -0 % 2 * 2 + 1;
export const C2 = -1 % 2 * 2 + 1;
export const C3 = -2 % 2 * 2 + 1;

```