### PR TITLE
Fix interface inherit

### DIFF
--- a/tygo/write.go
+++ b/tygo/write.go
@@ -179,7 +179,9 @@ func (g *PackageGenerator) writeInterfaceFields(
 		if _, isFunc := f.Type.(*ast.FuncType); isFunc {
 			continue
 		}
-		if !didContainNonFuncFields {
+		if didContainNonFuncFields {
+			s.WriteString(" |\n")
+		} else {
 			s.WriteByte(
 				'\n',
 			) // We need to write a newline so comments of generic components render nicely.

--- a/tygo/write.go
+++ b/tygo/write.go
@@ -180,7 +180,7 @@ func (g *PackageGenerator) writeInterfaceFields(
 			continue
 		}
 		if didContainNonFuncFields {
-			s.WriteString(" |\n")
+			s.WriteString(" &\n")
 		} else {
 			s.WriteByte(
 				'\n',


### PR DESCRIPTION
```go
package test_tygo

import "io"

type File interface {
	io.Reader
	io.Writer
	io.Closer

	Rename() bool
}

```

original

```ts
// Code generated by tygo. DO NOT EDIT.

//////////
// source: type.go

export type File = 
    any /* io.Reader */    any /* io.Writer */    any /* io.Closer */;

```

fixed

```ts
// Code generated by tygo. DO NOT EDIT.

//////////
// source: type.go

export type File = 
    any /* io.Reader */ |
    any /* io.Writer */ |
    any /* io.Closer */;

```