### PR TITLE
add `extends` configuration variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ packages:
     # in the output.
     exclude_files:
       - "private_stuff.go"
+
+    # Package that your type classes should extend. This is useful when
+    # attaching your types to a generic ORM.
+    extends: "SomeType"
 ```
 
 See also the source file [tygo/config.go](./tygo/config.go).

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ packages:
     exclude_files:
       - "private_stuff.go"
 
-    # Package that your type classes should extend. This is useful when
+    # Package that the generates Typescript types should extend. This is useful when
     # attaching your types to a generic ORM.
     extends: "SomeType"
 ```

--- a/tygo/config.go
+++ b/tygo/config.go
@@ -50,6 +50,9 @@ type PackageConfig struct {
 	// In "types" mode, only type comments are preserved.
 	// If "none" is supplied, no comments are preserved.
 	PreserveComments string `yaml:"preserve_comments"`
+
+	// Default interface for Typescript-generated interfaces to extend.
+	Extends string `yaml:"extends"`
 }
 
 type Config struct {

--- a/tygo/write_toplevel.go
+++ b/tygo/write_toplevel.go
@@ -113,6 +113,10 @@ func (g *PackageGenerator) writeTypeSpec(
 	if isStruct {
 		s.WriteString("export interface ")
 		s.WriteString(ts.Name.Name)
+		if g.conf.Extends != "" {
+			s.WriteString(" extends ")
+			s.WriteString(g.conf.Extends)
+		}
 
 		if ts.TypeParams != nil {
 			g.writeTypeParamsFields(s, ts.TypeParams.List)


### PR DESCRIPTION
the `extends` configuration variable allows you to specify a default class that the tygo-generated interfaces inherit from. This is useful if you have a generic data model class on the TypeScript side that you want your types that are generated from Go to inherit from.