### PR TITLE
Add support for new JSON struct tag option "omitzero"

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ type UserEntry struct {
 	MaybeFieldWithStar *string  `json:"address"`
 	Nickname           string   `json:"nickname,omitempty"`
 	Role               UserRole `json:"role"`
+  CreatedAt          time.Time `json:"created_at,omitzero"`
 
 	Complex    ComplexType `json:"complex"`
 	unexported bool        // Unexported fields are omitted
@@ -85,6 +86,7 @@ export interface UserEntry {
   address?: string;
   nickname?: string;
   role: UserRole;
+  createdAt?: string /* RFC3339 */;
   complex: ComplexType;
 }
 export interface ListUsersResponse {
@@ -200,10 +202,11 @@ You could use the `frontmatter` field in the config to inject `export type Genre
 
 **`tygo:emit` directive**
 
-Another way to generate types that cannot be directly represented in Go is to use a `//tygo:emit` directive to 
+Another way to generate types that cannot be directly represented in Go is to use a `//tygo:emit` directive to
 directly emit literal TS code.
-The directive can be used in two ways. A `tygo:emit` directive on a struct will emit the remainder of the directive 
+The directive can be used in two ways. A `tygo:emit` directive on a struct will emit the remainder of the directive
 text before the struct.
+
 ```golang
 // Golang input
 
@@ -215,7 +218,7 @@ type Book struct {
 ```
 
 ```typescript
-export type Genre = "novel" | "crime" | "fantasy"
+export type Genre = "novel" | "crime" | "fantasy";
 
 export interface Book {
   title: string;
@@ -224,11 +227,12 @@ export interface Book {
 ```
 
 A `//tygo:emit` directive on a string var will emit the contents of the var, useful for multi-line content.
+
 ```golang
 //tygo:emit
 var _ = `export type StructAsTuple=[
-  a:number, 
-  b:number, 
+  a:number,
+  b:number,
   c:string,
 ]
 `
@@ -238,16 +242,11 @@ type CustomMarshalled struct {
 ```
 
 ```typescript
-export type StructAsTuple=[
-  a:number, 
-  b:number, 
-  c:string,
-]
+export type StructAsTuple = [a: number, b: number, c: string];
 
 export interface CustomMarshalled {
   content: StructAsTuple[];
 }
-
 ```
 
 Generating types this way is particularly useful for tuple types, because a comma cannot be used in the `tstype` tag.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ export interface UserEntry {
   address?: string;
   nickname?: string;
   role: UserRole;
-  createdAt?: string /* RFC3339 */;
+  created_at?: string /* RFC3339 */;
   complex: ComplexType;
 }
 export interface ListUsersResponse {
@@ -202,11 +202,10 @@ You could use the `frontmatter` field in the config to inject `export type Genre
 
 **`tygo:emit` directive**
 
-Another way to generate types that cannot be directly represented in Go is to use a `//tygo:emit` directive to
+Another way to generate types that cannot be directly represented in Go is to use a `//tygo:emit` directive to 
 directly emit literal TS code.
-The directive can be used in two ways. A `tygo:emit` directive on a struct will emit the remainder of the directive
+The directive can be used in two ways. A `tygo:emit` directive on a struct will emit the remainder of the directive 
 text before the struct.
-
 ```golang
 // Golang input
 
@@ -218,7 +217,7 @@ type Book struct {
 ```
 
 ```typescript
-export type Genre = "novel" | "crime" | "fantasy";
+export type Genre = "novel" | "crime" | "fantasy"
 
 export interface Book {
   title: string;
@@ -227,12 +226,11 @@ export interface Book {
 ```
 
 A `//tygo:emit` directive on a string var will emit the contents of the var, useful for multi-line content.
-
 ```golang
 //tygo:emit
 var _ = `export type StructAsTuple=[
-  a:number,
-  b:number,
+  a:number, 
+  b:number, 
   c:string,
 ]
 `
@@ -242,11 +240,16 @@ type CustomMarshalled struct {
 ```
 
 ```typescript
-export type StructAsTuple = [a: number, b: number, c: string];
+export type StructAsTuple=[
+  a:number, 
+  b:number, 
+  c:string,
+]
 
 export interface CustomMarshalled {
   content: StructAsTuple[];
 }
+
 ```
 
 Generating types this way is particularly useful for tuple types, because a comma cannot be used in the `tstype` tag.

--- a/examples/simple/index.ts
+++ b/examples/simple/index.ts
@@ -27,6 +27,7 @@ export interface UserEntry {
   address?: string;
   nickname?: string;
   role: UserRole;
+  createdAt?: string /* RFC3339 */;
   complex: ComplexType;
 }
 export interface ListUsersResponse {

--- a/examples/simple/index.ts
+++ b/examples/simple/index.ts
@@ -27,7 +27,7 @@ export interface UserEntry {
   address?: string;
   nickname?: string;
   role: UserRole;
-  createdAt?: string /* RFC3339 */;
+  created_at?: string /* RFC3339 */;
   complex: ComplexType;
 }
 export interface ListUsersResponse {

--- a/examples/simple/simple.go
+++ b/examples/simple/simple.go
@@ -1,6 +1,10 @@
 package simple
 
-import "github.com/google/uuid"
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
 
 // Comments are kept :)
 type ComplexType map[string]map[uint16]*uint32
@@ -24,9 +28,10 @@ type UserEntry struct {
 		Bar uuid.UUID `json:"bar"`
 	} `json:"prefs"`
 
-	MaybeFieldWithStar *string  `json:"address"`
-	Nickname           string   `json:"nickname,omitempty"`
-	Role               UserRole `json:"role"`
+	MaybeFieldWithStar *string   `json:"address"`
+	Nickname           string    `json:"nickname,omitempty"`
+	Role               UserRole  `json:"role"`
+	CreatedAt          time.Time `json:"created_at,omitzero"`
 
 	Complex    ComplexType `json:"complex"`
 	unexported bool        // Unexported fields won't be in the output

--- a/tygo/write.go
+++ b/tygo/write.go
@@ -320,7 +320,7 @@ func (g *PackageGenerator) writeStructFields(s *strings.Builder, fields []*ast.F
 					continue
 				}
 
-				optional = jsonTag.HasOption("omitempty")
+				optional = jsonTag.HasOption("omitempty") || jsonTag.HasOption("omitzero")
 			}
 			yamlTag, err := tags.Get("yaml")
 			if err == nil {


### PR DESCRIPTION
See the [release notes of Go 1.24](https://tip.golang.org/doc/go1.24). 

go-yaml doesn't currently support this so I have only added it for the `json` tag.

closes #78