### PR TITLE
Use type mappings for inheritance

### DIFF
--- a/tygo/write_toplevel.go
+++ b/tygo/write_toplevel.go
@@ -176,9 +176,16 @@ func (g *PackageGenerator) writeTypeInheritanceSpec(s *strings.Builder, fields [
 				continue
 			}
 
-			name, valid := getInheritedType(f.Type, tstypeTag)
+			longType, valid := getInheritedType(f.Type, tstypeTag)
 			if valid {
-				inheritances = append(inheritances, name)
+				mappedTsType, ok := g.conf.TypeMappings[longType]
+				if ok {
+					inheritances = append(inheritances, mappedTsType)
+				} else {
+					// We can't use the fallback type because TypeScript doesn't allow extending "any".
+					inheritances = append(inheritances, longType)
+				}
+
 			}
 		}
 	}


### PR DESCRIPTION
This allows for extending a type from package A in package B using a config like this:

```go
// b.go

import "github.com/gzuidhof/tygo/a"

type TypeTwo {
   a.TypeOne `tstype:",required"`
}
```

```yaml
  - path: "github.com/gzuidhof/tygo/a"
    output_path: "../web/a.gen.ts"
  - path: "github.com/gzuidhof/tygo/b"
    output_path: "../web/b.gen.ts"
    type_mappings:
      a.TypeOne: "TypeOne"
    frontmatter: |
      import { TypeOne } from "./a.gen"
```