### PR TITLE
Prefer json tag over yaml:"-" when both are present

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This project is a maintained fork of gzuidhof/tygo, originally created by Guus Zuidhof. All core logic and ideas are credited to the original author. This fork exists to provide additional fixes and improvements ahead of upstream merges.
+
 # 🎑 tygo
 
 Tygo is a tool for generating Typescript typings from Golang source files that just works.
@@ -9,7 +11,7 @@ It preserves comments, understands constants and also supports non-struct `type`
 ## Installation
 
 ```shell
-go install github.com/gzuidhof/tygo@latest
+go install github.com/okaris/tygo@latest
 ```
 
 ## Example
@@ -104,7 +106,7 @@ Create a file `tygo.yaml` in which you specify which packages are to be converte
 
 ```yaml
 packages:
-  - path: "github.com/gzuidhof/tygo/examples/bookstore"
+  - path: "github.com/okaris/tygo/examples/bookstore"
     type_mappings:
       time.Time: "string /* RFC3339 */"
       null.String: "null | string"
@@ -127,7 +129,7 @@ The output Typescript file will be next to the Go source files.
 config := &tygo.Config{
   Packages: []*tygo.PackageConfig{
       &tygo.PackageConfig{
-          Path: "github.com/gzuidhof/tygo/examples/bookstore",
+          Path: "github.com/okaris/tygo/examples/bookstore",
       },
   },
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/gzuidhof/tygo/config"
-	"github.com/gzuidhof/tygo/tygo"
+	"github.com/okaris/tygo/config"
+	"github.com/okaris/tygo/tygo"
 	"github.com/spf13/cobra"
 )
 

--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"log"
 
-	"github.com/gzuidhof/tygo/tygo"
+	"github.com/okaris/tygo/tygo"
 	"gopkg.in/yaml.v2"
 )
 

--- a/examples/directive/directive.go
+++ b/examples/directive/directive.go
@@ -1,7 +1,7 @@
 // This example is here to reproduce Github issue #26
 // Directive comments should not be output.
 //
-// See https://github.com/gzuidhof/tygo/issues/26
+// See https://github.com/okaris/tygo/issues/26
 package directive
 
 // Comment above a directive

--- a/examples/directive/index.ts
+++ b/examples/directive/index.ts
@@ -6,7 +6,7 @@
 This example is here to reproduce Github issue #26
 Directive comments should not be output.
 
-See https://github.com/gzuidhof/tygo/issues/26
+See https://github.com/okaris/tygo/issues/26
 */
 
 /**

--- a/examples/embed/embed.go
+++ b/examples/embed/embed.go
@@ -1,6 +1,6 @@
 package embed
 
-import bookapp "github.com/gzuidhof/tygo/examples/bookstore"
+import bookapp "github.com/okaris/tygo/examples/bookstore"
 
 // TokenType Built-in type alias
 type TokenType string

--- a/examples/generic_any/any.go
+++ b/examples/generic_any/any.go
@@ -1,4 +1,4 @@
-// Example for https://github.com/gzuidhof/tygo/issues/65
+// Example for https://github.com/okaris/tygo/issues/65
 package genericany
 
 type AnyStructField[T any] struct {

--- a/examples/generic_any/index.ts
+++ b/examples/generic_any/index.ts
@@ -3,7 +3,7 @@
 //////////
 // source: any.go
 /*
-Example for https://github.com/gzuidhof/tygo/issues/65
+Example for https://github.com/okaris/tygo/issues/65
 */
 
 export interface AnyStructField<T extends any> {

--- a/examples/inheritance/inheritance.go
+++ b/examples/inheritance/inheritance.go
@@ -1,7 +1,7 @@
 package inheritance
 
 import (
-	bookapp "github.com/gzuidhof/tygo/examples/bookstore"
+	bookapp "github.com/okaris/tygo/examples/bookstore"
 )
 
 type Base struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gzuidhof/tygo
+module github.com/okaris/tygo
 
 go 1.18
 

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -10,7 +10,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w -X github.com/gzuidhof/tygo/cmd.version={{.Version}} -X github.com/gzuidhof/tygo/cmd.commit={{.Commit}} -X github.com/gzuidhof/tygo/cmd.commitDate={{.CommitDate}}
+      - -s -w -X github.com/okaris/tygo/cmd.version={{.Version}} -X github.com/okaris/tygo/cmd.commit={{.Commit}} -X github.com/okaris/tygo/cmd.commitDate={{.CommitDate}}
 archives:
   - id: tygo
     name_template: >-

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/gzuidhof/tygo/cmd"
+import "github.com/okaris/tygo/cmd"
 
 func main() {
 	cmd.Execute()

--- a/tygo.yaml
+++ b/tygo.yaml
@@ -4,26 +4,26 @@ type_mappings:
   time.Duration: "number /* int, ns */"
 
 packages:
-  - path: "github.com/gzuidhof/tygo/examples/bookstore"
+  - path: "github.com/okaris/tygo/examples/bookstore"
     type_mappings:
       time.Time: "string /* RFC 3339 formatted */"
       null.String: "string | null"
       uuid.UUID: "string"
-  - path: "github.com/gzuidhof/tygo/examples/abstract"
+  - path: "github.com/okaris/tygo/examples/abstract"
     indent: "  "
     exclude_files:
       - "excluded.go"
     frontmatter:
       | # We can define some additional text to put at the start of the file.
       export type Something = string | number;
-  - path: "github.com/gzuidhof/tygo/examples/simple"
+  - path: "github.com/okaris/tygo/examples/simple"
     fallback_type: unknown
-  - path: "github.com/gzuidhof/tygo/examples/inheritance"
+  - path: "github.com/okaris/tygo/examples/inheritance"
     fallback_type: unknown
     frontmatter:
       | # We can define some additional text to put at the start of the file.
       import * as bookapp from "../bookstore"
-  - path: "github.com/gzuidhof/tygo/examples/embed"
+  - path: "github.com/okaris/tygo/examples/embed"
     fallback_type: unknown
     type_mappings:
       bookapp.Book: "bookapp.Book"
@@ -31,13 +31,13 @@ packages:
     frontmatter:
       | # We can define some additional text to put at the start of the file.
       import * as bookapp from "../bookstore"
-  - path: "github.com/gzuidhof/tygo/examples/generic"
+  - path: "github.com/okaris/tygo/examples/generic"
     fallback_type: unknown
-  - path: "github.com/gzuidhof/tygo/examples/generic_any"
-  - path: "github.com/gzuidhof/tygo/examples/preserveTypeComments"
+  - path: "github.com/okaris/tygo/examples/generic_any"
+  - path: "github.com/okaris/tygo/examples/preserveTypeComments"
     fallback_type: unknown
     preserve_comments: "types"
-  - path: "github.com/gzuidhof/tygo/examples/noComments"
+  - path: "github.com/okaris/tygo/examples/noComments"
     fallback_type: unknown
     preserve_comments: "none"
   # Generate the "net/http" output example, note the output is in gitignore as it's pretty big
@@ -48,16 +48,16 @@ packages:
   # Generate the "time" output example, note the output is in gitignore as it's pretty big
   - path: "time"
     output_path: "./examples/time/index.ts"
-  - path: "github.com/gzuidhof/tygo/examples/yaml"
+  - path: "github.com/okaris/tygo/examples/yaml"
     output_path: "./examples/yaml/index.ts"
     flavor: "yaml"
-  - path: "github.com/gzuidhof/tygo/examples/interface"
-  - path: "github.com/gzuidhof/tygo/examples/directive"
-  - path: "github.com/gzuidhof/tygo/examples/emit"
+  - path: "github.com/okaris/tygo/examples/interface"
+  - path: "github.com/okaris/tygo/examples/directive"
+  - path: "github.com/okaris/tygo/examples/emit"
     exclude_files: 
       - "excluded.go"
-  - path: "github.com/gzuidhof/tygo/examples/rune"
+  - path: "github.com/okaris/tygo/examples/rune"
 
-  - path: "github.com/gzuidhof/tygo/examples/globalconfig"
+  - path: "github.com/okaris/tygo/examples/globalconfig"
   
 

--- a/tygo/testdata/fixtures/generic.md
+++ b/tygo/testdata/fixtures/generic.md
@@ -127,7 +127,7 @@ export type SingleSpecific = Single<string>;
 
 # Any field
 
-Example for https://github.com/gzuidhof/tygo/issues/65.
+Example for https://github.com/okaris/tygo/issues/65.
 ```go
 type AnyStructField[T any] struct {
   Value     T

--- a/tygo/write.go
+++ b/tygo/write.go
@@ -313,23 +313,17 @@ func (g *PackageGenerator) writeStructFields(s *strings.Builder, fields []*ast.F
 				panic(err)
 			}
 
-			jsonTag, err := tags.Get("json")
-			if err == nil {
+			jsonTag, jsonErr := tags.Get("json")
+			yamlTag, yamlErr := tags.Get("yaml")
+
+			if jsonErr == nil && jsonTag.Name != "-" {
 				name = jsonTag.Name
-				if name == "-" {
-					continue
-				}
-
 				optional = jsonTag.HasOption("omitempty") || jsonTag.HasOption("omitzero")
-			}
-			yamlTag, err := tags.Get("yaml")
-			if err == nil {
+			} else if yamlErr == nil && yamlTag.Name != "-" {
 				name = yamlTag.Name
-				if name == "-" {
-					continue
-				}
-
 				optional = yamlTag.HasOption("omitempty")
+			} else {
+				continue
 			}
 
 			tstypeTag, err := tags.Get("tstype")


### PR DESCRIPTION
Fixes #54.
When both json and yaml tags are specified on a struct field, and the yaml tag is explicitly set to "-", the field should still be included in the TypeScript output using the json tag. This change prioritizes the json tag in such cases, ensuring that valid fields are not incorrectly omitted.