### PR TITLE
Add support for byte type

### DIFF
--- a/tygo/write.go
+++ b/tygo/write.go
@@ -43,7 +43,7 @@ func getIdent(s string) string {
 	case "bool":
 		return "boolean"
 	case "int", "int8", "int16", "int32", "int64",
-		"uint", "uint8", "uint16", "uint32", "uint64",
+		"uint", "uint8", "byte", "uint16", "uint32", "uint64",
 		"float32", "float64",
 		"complex64", "complex128",
 		"rune":

--- a/tygo/write.go
+++ b/tygo/write.go
@@ -43,10 +43,10 @@ func getIdent(s string) string {
 	case "bool":
 		return "boolean"
 	case "int", "int8", "int16", "int32", "int64",
-		"uint", "uint8", "byte", "uint16", "uint32", "uint64",
+		"uint", "uint8", "uint16", "uint32", "uint64",
 		"float32", "float64",
 		"complex64", "complex128",
-		"rune":
+		"rune", "byte":
 		return "number /* " + s + " */"
 	}
 	return s
@@ -77,8 +77,8 @@ func (g *PackageGenerator) writeType(
 			s.WriteByte(')')
 		}
 	case *ast.ArrayType:
-		if v, ok := t.Elt.(*ast.Ident); ok && v.String() == "byte" {
-			s.WriteString("string")
+		if v, ok := t.Elt.(*ast.Ident); ok && (v.String() == "byte" || v.String() == "uint8") {
+			s.WriteString("string /* []" + v.String() + " */")
 			break
 		}
 		g.writeType(s, t.Elt, t, depth, true)


### PR DESCRIPTION
In Go, byte is an alias for uint8. However when tygo processes a struct with a field of type byte it does not treat it the same way as a struct with a field of type uint8.  This pull request allows tygo to treat Go byte fields as a TS number in the same way as uint8 fields.

For example, currently this Go struct converts to the following TS interface:
```go
type Hours struct {
	OpenHour    byte
	CloseHour   uint8
}
```

```typescript
export interface Hours {
	OpenHour: byte;
	CloseHour: number /* uint8 */;
}
```

After this change the same Go struct converts to:
```typescript
export interface Hours {
	OpenHour: number /* byte */;
	CloseHour: number /* uint8 */;
}
```